### PR TITLE
Allows versions of activerecord >= 3.2.0 in gemspec

### DIFF
--- a/enum_table.gemspec
+++ b/enum_table.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  gem.add_runtime_dependency 'activerecord', '~> 3.2.0'
+  gem.add_runtime_dependency 'activerecord', '>= 3.2.0'
   gem.add_development_dependency 'ritual', '~> 0.4.1'
 end


### PR DESCRIPTION
- I'm not really sure of the implications of this change, but this is
  a Rails 4 upgrade blocker
