### PR TITLE
ensure ids are always assigned as integers

### DIFF
--- a/lib/enum_table/reflection.rb
+++ b/lib/enum_table/reflection.rb
@@ -34,6 +34,7 @@ module EnumTable
     end
 
     def add_value(id, value)
+      id = id.to_i
       @strings_to_ids[value.to_s] = id
 
       cast_value = @type == :string ? value.to_s : value.to_sym


### PR DESCRIPTION
I had some trouble with ids sometimes being stored as strings... this was a problem, since the ids were stored as integers in the database, so I couldn't retrieve the enum value.
Maybe this is database dependent?
